### PR TITLE
Hyphen To Underscore NameConverter

### DIFF
--- a/Resources/config/symfony_services.yml
+++ b/Resources/config/symfony_services.yml
@@ -22,10 +22,15 @@ services:
             - ~
             - false
 
+    auto1.api.response.transformer.name_converter.decorator.hyphen_to_underscore_converter:
+        class: Auto1\ServiceAPIComponentsBundle\Service\NameConverter\HyphenToUnderscoreNameConverterDecorator
+        arguments:
+            - '@auto1.api.response.transformer.name_converter.camel_case_to_snake_case'
+
     auto1.api.response.transformer.name_converter.decorator.skip_convert_on_normalize:
         class: Auto1\ServiceAPIComponentsBundle\Service\NameConverter\SkipConvertOnNormalizeNameConverterDecorator
         arguments:
-            - '@auto1.api.response.transformer.name_converter.camel_case_to_snake_case'
+            - '@auto1.api.response.transformer.name_converter.decorator.hyphen_to_underscore_converter'
 
     auto1.api.response.transformer.normalizer:
         class: Symfony\Component\Serializer\Normalizer\ObjectNormalizer

--- a/Service/NameConverter/HyphenToUnderscoreNameConverterDecorator.php
+++ b/Service/NameConverter/HyphenToUnderscoreNameConverterDecorator.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Auto1\ServiceAPIComponentsBundle\Service\NameConverter;
+
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use function \str_replace;
+
+class HyphenToUnderscoreNameConverterDecorator implements NameConverterInterface
+{
+    /** @var NameConverterInterface */
+    private $nameConverter;
+
+    /**
+     * SnakeCaseToCamelCaseOnDenormalizeDecoratorNameConverter constructor.
+     *
+     * @param NameConverterInterface $nameConverter
+     */
+    public function __construct(NameConverterInterface $nameConverter)
+    {
+        $this->nameConverter = $nameConverter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function normalize($propertyName)
+    {
+        return $this->nameConverter->normalize($propertyName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function denormalize($propertyName)
+    {
+        return $this->nameConverter->denormalize(str_replace('-', '_', $propertyName));
+    }
+}

--- a/Service/NameConverter/HyphenToUnderscoreNameConverterDecorator.php
+++ b/Service/NameConverter/HyphenToUnderscoreNameConverterDecorator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Auto1\ServiceAPIComponentsBundle\Service\NameConverter;
 
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
-use function \str_replace;
 
 class HyphenToUnderscoreNameConverterDecorator implements NameConverterInterface
 {
@@ -12,8 +11,7 @@ class HyphenToUnderscoreNameConverterDecorator implements NameConverterInterface
     private $nameConverter;
 
     /**
-     * SnakeCaseToCamelCaseOnDenormalizeDecoratorNameConverter constructor.
-     *
+     * HyphenToUnderscoreNameConverterDecorator constructor.
      * @param NameConverterInterface $nameConverter
      */
     public function __construct(NameConverterInterface $nameConverter)
@@ -34,6 +32,6 @@ class HyphenToUnderscoreNameConverterDecorator implements NameConverterInterface
      */
     public function denormalize($propertyName)
     {
-        return $this->nameConverter->denormalize(str_replace('-', '_', $propertyName));
+        return $this->nameConverter->denormalize(\str_replace('-', '_', $propertyName));
     }
 }

--- a/Tests/Service/Serializer/NameConverter/HyphenToUnderscoreNameConverterDecoratorTest.php
+++ b/Tests/Service/Serializer/NameConverter/HyphenToUnderscoreNameConverterDecoratorTest.php
@@ -4,27 +4,29 @@ declare(strict_types=1);
 namespace Auto1\ServiceAPIComponentsBundle\Tests\Service\Serializer\NameConverter;
 
 use Auto1\ServiceAPIComponentsBundle\Service\NameConverter\HyphenToUnderscoreNameConverterDecorator;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 class HyphenToUnderscoreNameConverterDecoratorTest extends TestCase
 {
-    /** @var NameConverterInterface|MockObject */
+    /** @var NameConverterInterface|ObjectProphecy */
     private $decoratedConverterMock;
 
+    /**
+     * {@inheritDoc}
+     */
     protected function setUp()
     {
-        $this->decoratedConverterMock = $this->createMock(NameConverterInterface::class);
+        $this->decoratedConverterMock = $this->prophesize(NameConverterInterface::class);
     }
 
-    public function testConstruct()
+    /**
+     * {@inheritDoc}
+     */
+    protected function tearDown()
     {
-        $this->decoratedConverterMock
-            ->expects($this->never())
-            ->method($this->anything());
-
-        new HyphenToUnderscoreNameConverterDecorator($this->decoratedConverterMock);
+        $this->decoratedConverterMock->checkProphecyMethodsPredictions();
     }
 
     /**
@@ -36,10 +38,9 @@ class HyphenToUnderscoreNameConverterDecoratorTest extends TestCase
     public function testDenormalize(string $propertyName, string $expectedResult)
     {
         $this->decoratedConverterMock
-            ->expects($this->once())
-            ->method('denormalize')
-            ->with($expectedResult)
-            ->willReturn($expectedResult);
+            ->denormalize($expectedResult)
+            ->willReturn($expectedResult)
+            ->shouldBeCalledOnce();
 
         $converter = $this->getCut();
 
@@ -56,10 +57,9 @@ class HyphenToUnderscoreNameConverterDecoratorTest extends TestCase
     public function testNormalize(string $propertyName)
     {
         $this->decoratedConverterMock
-            ->expects($this->once())
-            ->method('normalize')
-            ->with($propertyName)
-            ->willReturn($propertyName);
+            ->normalize($propertyName)
+            ->willReturn($propertyName)
+            ->shouldBeCalledOnce();
 
         $converter = $this->getCut();
 
@@ -96,6 +96,6 @@ class HyphenToUnderscoreNameConverterDecoratorTest extends TestCase
 
     private function getCut(): HyphenToUnderscoreNameConverterDecorator
     {
-        return new HyphenToUnderscoreNameConverterDecorator($this->decoratedConverterMock);
+        return new HyphenToUnderscoreNameConverterDecorator($this->decoratedConverterMock->reveal());
     }
 }

--- a/Tests/Service/Serializer/NameConverter/HyphenToUnderscoreNameConverterDecoratorTest.php
+++ b/Tests/Service/Serializer/NameConverter/HyphenToUnderscoreNameConverterDecoratorTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace Auto1\ServiceAPIComponentsBundle\Tests\Service\Serializer\NameConverter;
+
+use Auto1\ServiceAPIComponentsBundle\Service\NameConverter\HyphenToUnderscoreNameConverterDecorator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+class HyphenToUnderscoreNameConverterDecoratorTest extends TestCase
+{
+    /** @var NameConverterInterface|MockObject */
+    private $decoratedConverterMock;
+
+    protected function setUp()
+    {
+        $this->decoratedConverterMock = $this->createMock(NameConverterInterface::class);
+    }
+
+    public function testConstruct()
+    {
+        $this->decoratedConverterMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        new HyphenToUnderscoreNameConverterDecorator($this->decoratedConverterMock);
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string $expectedResult
+     *
+     * @dataProvider denormalizedNamesDataProvider
+     */
+    public function testDenormalize(string $propertyName, string $expectedResult)
+    {
+        $this->decoratedConverterMock
+            ->expects($this->once())
+            ->method('denormalize')
+            ->with($expectedResult)
+            ->willReturn($expectedResult);
+
+        $converter = $this->getCut();
+
+        $result = $converter->denormalize($propertyName);
+
+        $this->assertSame($expectedResult, $result);
+    }
+
+    /**
+     * @param string $propertyName
+     *
+     * @dataProvider denormalizedNamesDataProvider
+     */
+    public function testNormalize(string $propertyName)
+    {
+        $this->decoratedConverterMock
+            ->expects($this->once())
+            ->method('normalize')
+            ->with($propertyName)
+            ->willReturn($propertyName);
+
+        $converter = $this->getCut();
+
+        $result = $converter->normalize($propertyName);
+
+        $this->assertSame($propertyName, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function normalizedNamesDataProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'normal' => ['propertyName'],
+            'underscore' => ['property_name'],
+            'hyphen' => ['property-name'],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function denormalizedNamesDataProvider(): array
+    {
+        return [
+            'empty' => ['', ''],
+            'normal' => ['propertyName', 'propertyName'],
+            'underscore' => ['Property_Name', 'Property_Name'],
+            'hyphen' => ['Property-Name', 'Property_Name'],
+        ];
+    }
+
+    private function getCut(): HyphenToUnderscoreNameConverterDecorator
+    {
+        return new HyphenToUnderscoreNameConverterDecorator($this->decoratedConverterMock);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "symfony/console": "~3.0|~4.0",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^6.5",
         "symfony/phpunit-bridge": "^3.3.8",
         "phpspec/prophecy": "^1.7.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,8 +2,7 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
-         backupGlobals="false"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php"
 >


### PR DESCRIPTION
Add additional decorator for replace hyphen in names to undersocre (for using together with CamelCaseToSnakeCaseNameConverter).
Update to last version PHPUnit, that support bundle PHP version.