### PR TITLE
Added exit status to the command

### DIFF
--- a/Command/EndpointsDebugCommand.php
+++ b/Command/EndpointsDebugCommand.php
@@ -38,7 +38,7 @@ class EndpointsDebugCommand extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return int|null|void
+     * @return int
      * @throws \ReflectionException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -53,6 +53,8 @@ class EndpointsDebugCommand extends Command
         foreach ($endpoints as $endpoint) {
             $this->dumpEndpoint($output, $endpoint);
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Since [Symfony 4.4](https://symfony.com/blog/new-in-symfony-4-4-console-improvements) its deprecated to not return the command exit status. 
And from Symfony 5 is mandatory to return it.