### PR TITLE
Add missing property for PHP 8.2 compatibility

### DIFF
--- a/Service/Logger/LoggerAwareTrait.php
+++ b/Service/Logger/LoggerAwareTrait.php
@@ -11,6 +11,11 @@ use Psr\Log\NullLogger;
 trait LoggerAwareTrait
 {
     /**
+     * @var LoggerInterface
+     */
+    private $traitLogger;
+
+    /**
      * @return LoggerInterface
      */
     protected function getLogger() : LoggerInterface


### PR DESCRIPTION
This PR adds a missing property to allow PHP 8.2 compatibility.

More about the deprecation of dynamic properties: https://wiki.php.net/rfc/deprecate_dynamic_properties