### PR TITLE
PP-9983: Allow request body in DELETE method

### DIFF
--- a/Service/Endpoint/EndpointProviderConfiguration.php
+++ b/Service/Endpoint/EndpointProviderConfiguration.php
@@ -18,7 +18,6 @@ class EndpointProviderConfiguration implements EndpointProviderInterface
 {
     const METHODS_WITHOUT_BODY = [
         EndpointInterface::METHOD_GET,
-        EndpointInterface::METHOD_DELETE,
     ];
 
     const DEFAULT_FORMAT = EndpointInterface::FORMAT_JSON;


### PR DESCRIPTION
Even if it is not the recommended approach for REST APIs, the HTTP RFC explicitly allows payloads in DELETE requests, even though their semantics are not defined and may be ignored by some servers.

We need this change because one of the internal service endpoints requires a body with DELETE.

Reference: [RFC 9110 - Section 9.3.5 DELETE](https://www.rfc-editor.org/rfc/rfc9110.html#name-delete)